### PR TITLE
Disable nufi snap by default

### DIFF
--- a/src/lib/main/stores/config.ts
+++ b/src/lib/main/stores/config.ts
@@ -45,7 +45,9 @@ const initialConfigState: WeldConfig = {
   ignoreUnsafeUsageError: false,
   enablePersistence: true,
   storage: defaultStorage,
-  customWallets: true,
+  customWallets: {
+    blacklist: ["nufiSnap"],
+  },
   wallet: {},
   extensions: {},
 };


### PR DESCRIPTION
## 📌 Description

Disables nufi snap custom wallet by default because it adds a lot of console errors.
It remains as a opt-in feature.