### PR TITLE
update package lock after changeset version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,4 +52,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Default OIDC setup for npm publishing
+          NPM_TOKEN: '' #https://github.com/changesets/changesets/issues/1152#issuecomment-3190884868
           NPM_CONFIG_PROVENANCE: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Version or publish
         uses: changesets/action@v1
         with:
-          version: npx changeset version
+          version: npm run version
           publish: npm run release
           commit: "chore: version packages"
           title: "chore: version packages"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   ],
   "scripts": {
     "build:packages": "npm run publish --workspace=core && npm run publish --workspace=plugins/hodei",
+    "version": "changeset version && npm install --package-lock-only",
     "release": "npm run build:packages && changeset publish",
     "build": "turbo run build",
     "dev": "turbo watch build & turbo run dev",


### PR DESCRIPTION
## 📌 Description

Fix package lock out of sync after changset version action by running npm i --package-lock-only after

Attempts to fix OIDC config