### PR TITLE
Fix/trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: Release
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,10 +29,12 @@ jobs:
         with:
           node-version: 22
           cache: npm
-          registry-url: https://registry.npmjs.org/
 
       - run: npm ci
 
+      - name: Update npm to 11.5.1+
+        run: npm install -g npm@latest
+        
       - name: Check & test
         run: |
           npx turbo run check test \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,8 @@ jobs:
       - run: npm ci
 
       - name: Update npm to 11.5.1+
-        run: npm install -g npm@latest
-        
+        run: npm install -g npm@11
+
       - name: Check & test
         run: |
           npx turbo run check test \

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build:packages": "npm run publish --workspace=core && npm run publish --workspace=plugins/hodei",
     "version": "changeset version && npm install --package-lock-only",
-    "release": "npm run build:packages && changeset publish",
+    "release": "npm run build:packages && changeset publish --provenance",
     "build": "turbo run build",
     "dev": "turbo watch build & turbo run dev",
     "lint": "turbo run lint",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build:packages": "npm run publish --workspace=core && npm run publish --workspace=plugins/hodei",
     "version": "changeset version && npm install --package-lock-only",
-    "release": "npm run build:packages && changeset publish --provenance",
+    "release": "npm run build:packages && changeset publish",
     "build": "turbo run build",
     "dev": "turbo watch build & turbo run dev",
     "lint": "turbo run lint",


### PR DESCRIPTION
## 📌 Description

Fixes release workflow to work with npm trusted publishing by forcing npm version to at least 11 (the latest needed for trusted publishing)

[successfully released](https://github.com/Cardano-Forge/weld/actions/runs/23462503874)